### PR TITLE
Raise an error if supp data does not match the main data

### DIFF
--- a/R/supp.R
+++ b/R/supp.R
@@ -189,7 +189,7 @@ combine_supp_helper <- function(x, dataset) {
       ))
     wide_x <- wide_x %>%
       mutate(IDVARVAL = fun_convert_id_var(.data$IDVARVAL)) %>%
-      rename_with(.fn=recode, IDVARVAL=id_var) #Given there is only one IDVAR per df we can just rename
+      dplyr::rename_with(.fn=dplyr::recode, IDVARVAL=id_var) #Given there is only one IDVAR per df we can just rename
     
     #Verify that every row in the SUPP data is merged into the final data
     col_rowid <- paste0(max(c(names(dataset), names(wide_x))), "X")

--- a/tests/testthat/test-supp.R
+++ b/tests/testthat/test-supp.R
@@ -201,3 +201,13 @@ test_that("combine_supp works with different IDVARVAL classes", {
 test_that("combine_supp works with without QEVAL", {
    expect_silent(combine_supp(admiral_tr, admiral_supptr))
 })
+
+test_that("supp data that does not match the main data will raise an error", {
+  sdtm_suppae_extra <- sdtm_suppae
+  sdtm_suppae_extra$IDVARVAL[1] <- 99
+  expect_error(
+    combine_supp(sdtm_ae, sdtm_suppae_extra),
+    regexp="1 rows with IDVAR AESEQ did not merge from the supp data to the main data",
+    fixed=TRUE
+  )
+})


### PR DESCRIPTION
Fix #31 

This will detect missing rows when merging supplemental data and then raise an error when the merge is incomplete.

While working on this, I changed some of the functions to use base R instead of tidyverse style piping and tidyverse functions.  I did it because I was trying to ensure that I understood what the function was doing, but if preferable to change that back, I can.

I also moved the function-in-a-function from the map command to a separate helper function.  I did this to try to make it easier to trace through issues.