### PR TITLE
Suppress messages from testing so that successful testing is silent

### DIFF
--- a/tests/testthat/test-build.R
+++ b/tests/testthat/test-build.R
@@ -1,6 +1,6 @@
-
 load(metacore::metacore_example("pilot_ADaM.rda"))
 spec <- metacore %>% select_dataset("ADSL")
+
 test_that("drop_unspec_vars", {
   data <- haven::read_xpt(metatools_example("adsl.xpt")) %>%
     mutate(foo = "Hello", foo2 = "world")
@@ -10,13 +10,12 @@ test_that("drop_unspec_vars", {
     pull(variable)
   man_dat <- data %>%
     select(all_of(man_vars))
-  drop_unspec_vars(data, spec) %>%
-    expect_equal(man_dat)
-  expect_message(drop_unspec_vars(data, spec),
-                 label = "The following variable(s) were dropped:\n  foo\n  foo2")
-
+  expect_message(
+    value <- drop_unspec_vars(data, spec),
+    label = "The following variable(s) were dropped:\n  foo\n  foo2"
+  )
+  expect_equal(value, man_dat)
 })
-
 
 test_that("build_from_derived", {
   ds_list <- list(DM = haven::read_xpt(metatools_example("dm.xpt")))
@@ -84,12 +83,16 @@ test_that("build_from_derived", {
 
 
   # Pulling through from one dataset when spec has more than one
-  adae_auto_adsl_only <- build_from_derived(spec2,
-                                  ds_list = list("ADSL" = safetyData::adam_adsl),
-                                  predecessor_only = FALSE,
-                                  keep = FALSE
-  ) |>
-     order_cols(spec2)
+  adae_auto_adsl_only <-
+    suppressMessages(
+      build_from_derived(
+        spec2,
+        ds_list = list("ADSL" = safetyData::adam_adsl),
+        predecessor_only = FALSE,
+        keep = FALSE
+      ) |>
+        order_cols(spec2)
+    )
   adsl_man <- order_cols(adsl_part, spec2)
   expect_equal(adae_auto_adsl_only, adsl_man)
 
@@ -100,18 +103,21 @@ test_that("build_from_derived", {
                                   predecessor_only = FALSE,
                                   keep = FALSE
   )
-  expect_equal(adae_auto,adae_man)
+  expect_equal(adae_auto, adae_man)
 
-  expect_warning(build_from_derived(spec2,
-                                    ds_list = list(safetyData::sdtm_ae, adsl),
-                                    predecessor_only = FALSE,
-                                    keep = FALSE
-  ))
-
-
+  expect_warning(
+    expect_message(
+      build_from_derived(
+        spec2,
+        ds_list = list(safetyData::sdtm_ae, adsl),
+        predecessor_only = FALSE,
+        keep = FALSE
+      ),
+      regexp = "Not all datasets provided. Only variables from ADSL will be gathered."
+    ),
+    regexp = "The following dataset\\(s\\) have no predecessors and will be ignored:\nsafetydata::sdtm_ae"
+  )
 })
-
-
 
 test_that("add_variables", {
    load(metacore::metacore_example("pilot_ADaM.rda"))

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -1,15 +1,15 @@
-
 # Load data to use across tests
 load(metacore::metacore_example("pilot_ADaM.rda"))
 spec <- metacore %>% select_dataset("ADSL")
 data <- haven::read_xpt(metatools_example("adsl.xpt"))
 mod_ds_vars <- spec$ds_vars %>%
    mutate(core = if_else(variable %in% c("TRT01PN", "DISCONFL"), "Required", core))
-spec_mod <- metacore::metacore(spec$ds_spec, mod_ds_vars, spec$var_spec, spec$value_spec, spec$derivations, spec$codelist) %>%
-   suppressWarnings()
+spec_mod <-
+  metacore::metacore(spec$ds_spec, mod_ds_vars, spec$var_spec, spec$value_spec, spec$derivations, spec$codelist) %>%
+  suppressWarnings() |>
+  suppressMessages()
 
 test_that("get_bad_ct works correctly", {
-
    # test na_acceptable
    expect_equal(get_bad_ct(data, spec, "DISCONFL"), character(0))
    expect_equal(get_bad_ct(data, spec, "DISCONFL", TRUE), character(0))
@@ -22,7 +22,6 @@ test_that("get_bad_ct works correctly", {
    data_na <- data %>%
       mutate(DISCONFL = if_else(dplyr::row_number() == 1, NA_character_, DISCONFL))
    expect_equal(get_bad_ct(data_na, spec_mod, "DISCONFL"), c(NA_character_, ""))
-
 })
 
 test_that("check_ct_col works correctly", {
@@ -34,7 +33,10 @@ test_that("check_ct_col works correctly", {
    expect_equal(check_ct_col(data, spec, "TRT01PN"), data)
 
    # Test permitted Values
-   spec2 <- metacore::spec_to_metacore(metacore::metacore_example("p21_mock.xlsx"), quiet = TRUE)
+   spec2 <-
+     suppressMessages(
+       metacore::spec_to_metacore(metacore::metacore_example("p21_mock.xlsx"), quiet = TRUE)
+     )
    expect_equal(check_ct_col(data, spec2, ARM), data)
 
    # Test external dictionaries
@@ -89,11 +91,10 @@ test_that("check_ct_data works correctly", {
    expect_error(check_ct_data(data, spec, omit_vars = c("A", "B")))
    expect_error(check_ct_data(data, spec, FALSE, omit_vars = c("DISCONFL", "DSRAEFL")))
    expect_equal(check_ct_data(data, spec_mod, na_acceptable = NULL, omit_vars = "DISCONFL"), data)
-
 })
 
 test_that("variable_check works correctly", {
-   expect_equal(check_variables(data, spec), data)
+   expect_equal(suppressMessages(check_variables(data, spec)), data)
    data_miss <- data %>% select(-1)
    expect_error(check_variables(data_miss, spec))
    data_extra <- data %>% mutate(foo = "hello")

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -1,5 +1,7 @@
-
-spec <- metacore::spec_to_metacore(metacore::metacore_example("p21_mock.xlsx"), quiet = TRUE)
+spec <-
+  suppressMessages(
+    metacore::spec_to_metacore(metacore::metacore_example("p21_mock.xlsx"), quiet = TRUE)
+  )
 load(metacore::metacore_example("pilot_ADaM.rda"))
 spec2 <- metacore %>% select_dataset("ADSL")
 dm <- haven::read_xpt(metatools_example("dm.xpt"))

--- a/tests/testthat/test-supp.R
+++ b/tests/testthat/test-supp.R
@@ -1,4 +1,3 @@
-
 test_that("build_qnam", {
    full_ae <- safetyData::sdtm_suppae %>%
       select(-QORIG, -QEVAL, -QLABEL) %>%
@@ -102,7 +101,10 @@ test_that("make_supp_qual", {
    expect_error(make_supp_qual(ae, metacore),
                 "Requires either a subsetted metacore object or a dataset name")
    #Testing without supp columns specified
-   metacore_old <- metacore::spec_to_metacore(metacore::metacore_example("SDTM_spec_CDISC_pilot.xlsx"), quiet = TRUE)
+   metacore_old <-
+     suppressMessages(
+       metacore::spec_to_metacore(metacore::metacore_example("SDTM_spec_CDISC_pilot.xlsx"), quiet = TRUE)
+     )
    expect_error(make_supp_qual(ae, metacore_old, "AE"),
                 "No supplemental variables specified in metacore object. Please check your specifications")
 


### PR DESCRIPTION
While working through the other two PRs that I just submitted, I noticed the messages that were unrelated to the work I was doing. This PR silences those messages. The messages mostly come from the `metacore` package printing messages like "Metadata successfully imported" and "Loading in metacore object with suppressed warnings".