### PR TITLE
83 create var from codelist extentsion

### DIFF
--- a/R/codelists.R
+++ b/R/codelists.R
@@ -105,7 +105,7 @@ create_subgrps <- function(ref_vec, grp_defs) {
 #' create_var_from_codelist(data, spec, "VAR2", "SEX")
 #' create_var_from_codelist(data, spec, VAR1, SEX, decode_to_code = FALSE)
 create_var_from_codelist <- function(data, metacore, input_var, out_var, dataset = NULL,
-                                     decode_to_code = TRUE, create_from_out_var = TRUE) {
+                                     decode_to_code = TRUE, create_from_out_var = TRUE, strict = FALSE) {
 
    if (create_from_out_var) {
       code_translation <- get_control_term(metacore, {{ out_var }}, {{ dataset }})
@@ -126,8 +126,15 @@ create_var_from_codelist <- function(data, metacore, input_var, out_var, dataset
 
    codelist <- code_translation %>%
       pull({{ derive_from }})
-   print(values)
-   print(code_translation)
+
+   miss <- setdiff(values, codelist)
+
+   if (length(miss) > 0 && strict == TRUE) {
+      warning(
+         paste("One or more values present in the input dataset are not present in the codelist:",
+         paste(miss, collapse = ", "), sep = " ")
+      )
+   }
 
    input_var_str <- as_label(enexpr(input_var)) %>%
       str_remove_all("\"")

--- a/R/codelists.R
+++ b/R/codelists.R
@@ -73,6 +73,7 @@ create_subgrps <- function(ref_vec, grp_defs) {
 #' @param metacore A metacore object to get the codelist from. If the `out_var`
 #'   has different codelists for different datasets the metacore object will
 #'   need to be subsetted using `select_dataset` from the metacore package.
+#' @param dataset Specify the parent dataset of the parameter to be created.
 #' @param input_var Name of the variable that will be translated for the new
 #'   column
 #' @param out_var Name of the output variable. Note: the grouping will always be
@@ -80,6 +81,12 @@ create_subgrps <- function(ref_vec, grp_defs) {
 #' @param decode_to_code Direction of the translation. By default assumes the
 #'   `input_var` is the decode column of the codelist. Set to `FALSE` if the
 #'   `input_var` is the code column of the codelist
+#' @param create_from_out_var Specifies the variable from which the codelist
+#'   should be taken. By default is out_var.
+#' @param strict A logical value indiciating whether to perform strict checking
+#'   against the codelist. If `TRUE` will issue a warning if values in the `input_var`
+#'   column are not present in the codelist. If `FALSE` no warning is issued and
+#'   values not present in the codelist will likely result in `NA` results.
 #'
 #' @return Dataset with a new column added
 #' @export
@@ -104,7 +111,7 @@ create_subgrps <- function(ref_vec, grp_defs) {
 #' create_var_from_codelist(data, spec, VAR2, SEX)
 #' create_var_from_codelist(data, spec, "VAR2", "SEX")
 #' create_var_from_codelist(data, spec, VAR1, SEX, decode_to_code = FALSE)
-create_var_from_codelist <- function(data, metacore, input_var, out_var, dataset = NULL,
+create_var_from_codelist <- function(data, metacore, dataset = NULL, input_var, out_var,
                                      decode_to_code = TRUE, create_from_out_var = TRUE, strict = FALSE) {
 
    if (create_from_out_var) {
@@ -129,7 +136,7 @@ create_var_from_codelist <- function(data, metacore, input_var, out_var, dataset
 
    miss <- setdiff(values, codelist)
 
-   if (length(miss) > 0 && strict == TRUE) {
+   if (strict == TRUE && length(miss) > 0) {
       warning(
          paste("One or more values present in the input dataset are not present in the codelist:",
          paste(miss, collapse = ", "), sep = " ")

--- a/R/codelists.R
+++ b/R/codelists.R
@@ -104,9 +104,9 @@ create_subgrps <- function(ref_vec, grp_defs) {
 #' create_var_from_codelist(data, spec, VAR2, SEX)
 #' create_var_from_codelist(data, spec, "VAR2", "SEX")
 #' create_var_from_codelist(data, spec, VAR1, SEX, decode_to_code = FALSE)
-create_var_from_codelist <- function(data, metacore, input_var, out_var,
+create_var_from_codelist <- function(data, metacore, input_var, out_var, dataset = NULL,
                                      decode_to_code = TRUE) {
-   code_translation <- get_control_term(metacore, {{ out_var }})
+   code_translation <- get_control_term(metacore, {{ out_var }}, {{ dataset }})
    input_var_str <- as_label(enexpr(input_var)) %>%
       str_remove_all("\"")
    if (is.vector(code_translation) | !("decode" %in% names(code_translation))) {

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -56,6 +56,56 @@ test_that("create_var_from_codelist", {
      pull(TRT01PN)
   expect_equal(num_out, c(0,  0, 81, 54, 81,0))
 
+  # Test arg `create_from_out_var = FALSE`
+  data_param <- tibble::tribble(
+     ~USUBJID, ~PARAMCD,
+     1, "SYSBP",
+     2, "DIABP",
+     3, "PULSE",
+     4, "WEIGHT",
+     5, "HEIGHT",
+     6, "TEMP",
+     7, "DUMMY01",
+     8, "DUMMY02"
+  )
+
+  create_var_from_codelist(
+     data = data_param,
+     metacore = metacore,
+     dataset = ADVS,
+     input_var = PARAMCD,
+     out_var = PARAM,
+     decode_to_code = FALSE,
+     create_from_out_var = FALSE
+  ) %>%
+     pull(PARAM) %>%
+     expect_equal(
+        c(
+           "Systolic Blood Pressure (mmHg)",
+           "Diastolic Blood Pressure (mmHg)",
+           "Pulse Rate (beats/min)",
+           "Weight (kg)",
+           "Height (cm)",
+           "Temperature (C)",
+           NA,
+           NA
+        )
+     )
+
+  # Test warning where arg `strict == TRUE`
+  expect_warning(
+     create_var_from_codelist(
+        data = data_param,
+        metacore = metacore,
+        dataset = ADVS,
+        input_var = PARAMCD,
+        out_var = PARAM,
+        decode_to_code = FALSE,
+        create_from_out_var = FALSE,
+        strict = TRUE
+     )
+  )
+
   # Test for Variable not in specs
   expect_error(create_var_from_codelist(data, spec, VAR2, FOO))
 })


### PR DESCRIPTION
Closes issue #83 

Primary update: Allows the user to create a new variable using the `input_var` as the variable from which to build the codelist. 

Other updates:

1. Allows the user to specify a dataset if they are using a combined metacore object (i.e., have not used `metacore::select_dataset`.
2. Allows the user to specify the `strict` option. This option returns a warning and a list of values from the `input_var` column in the input dataset that do not appear in the codelist. Can be useful when performing checks to ensure your controlled terminology is setup correctly.