### PR TITLE
99 create var from codelist bugfix

### DIFF
--- a/R/codelists.R
+++ b/R/codelists.R
@@ -182,10 +182,11 @@ type is {typeof(code_translation)}. Check the structure of the codelist in the \
    codelist <- code_translation |> pull(ref_var)
 
    miss <- setdiff(values, codelist)
-   if (strict == TRUE && length(miss) > 0) {
+   n_miss <- length(miss)
+   if (strict == TRUE && n_miss > 0) {
       cli_warn(
-         "In {.fn create_var_from_codelist}: The following value{?s} present in the
-input dataset {?is/are} not present in the codelist: {miss}")
+         "In {.fn create_var_from_codelist}: The following {qty(n_miss)}value{?s}
+present in the input dataset {qty(n_miss)}{?is/are} not present in the codelist: {miss}")
    }
 
    input_var_str <- as_label(enexpr(input_var)) |>
@@ -264,7 +265,7 @@ create_cat_var <- function(data, metacore, ref_var, grp_var, num_grp_var = NULL,
    # Assign group definitions and labels
    grp_defs <- pull(ct, code)
    grp_labs <- if (create_from_decode) pull(ct, decode) else grp_defs
-     
+
    out <- data %>%
       mutate({{ grp_var }} := create_subgrps({{ ref_var }}, grp_defs, grp_labs))
 

--- a/R/codelists.R
+++ b/R/codelists.R
@@ -1,4 +1,3 @@
-
 #' Dash to Equation
 #'
 #' Converts strings that are #-# style to a logical expression (but in a string format)
@@ -7,11 +6,11 @@
 #' @return string
 #' @noRd
 dash_to_eq <- function(string) {
-   front <- str_extract(string, "^.*(?=\\-)")
-   front_eq <- if_else(str_detect(front, "<|>|="), front, paste0(">=", front))
-   back <- str_extract(string, "(?<=\\-).*$")
-   back_eq <- if_else(str_detect(back, "<|>|="), back, paste0("<=", back))
-   paste0("x", front_eq, " & x", back_eq)
+  front <- str_extract(string, "^.*(?=\\-)")
+  front_eq <- if_else(str_detect(front, "<|>|="), front, paste0(">=", front))
+  back <- str_extract(string, "(?<=\\-).*$")
+  back_eq <- if_else(str_detect(back, "<|>|="), back, paste0("<=", back))
+  paste0("x", front_eq, " & x", back_eq)
 }
 
 
@@ -33,53 +32,58 @@ dash_to_eq <- function(string) {
 #' create_subgrps(c(1:10), c("<2", "2-<5", ">=5"))
 #' create_subgrps(c(1:10), c("<2", "2-<5", ">=5"), c("<2 years", "2-5 years", ">=5 years"))
 create_subgrps <- function(ref_vec, grp_defs, grp_labs = NULL) {
-   if (!is.numeric(ref_vec)) { cli_abort("ref_vec must be numeric") }
-   if (is.null(grp_labs)) { grp_labs <- grp_defs }
+  if (!is.numeric(ref_vec)) {
+    cli_abort("ref_vec must be numeric")
+  }
+  if (is.null(grp_labs)) {
+    grp_labs <- grp_defs
+  }
 
-   # Create equations used to derive the subgroups
-   equations <- case_when(
-      str_detect(grp_defs, "-") ~ paste0("function(x){if_else(", dash_to_eq(grp_defs), ", '", grp_labs, "', '')}"),
-      str_detect(grp_defs, "^(<\\s?=|>\\s?=|<|>)\\s?\\d+") ~ paste0("function(x){if_else(x", grp_defs, ",'", grp_labs, "', '')}"),
-      TRUE ~ NA_character_
-   )
+  # Create equations used to derive the subgroups
+  equations <- case_when(
+    str_detect(grp_defs, "-") ~ paste0("function(x){if_else(", dash_to_eq(grp_defs), ", '", grp_labs, "', '')}"),
+    str_detect(grp_defs, "^(<\\s?=|>\\s?=|<|>)\\s?\\d+") ~ paste0("function(x){if_else(x", grp_defs, ",'", grp_labs, "', '')}"),
+    TRUE ~ NA_character_
+  )
 
-   # Apply equations
-   if (all(!is.na(equations))) {
-      functions <- equations %>%
-         map(~ eval(parse(text = .)))
-      out <- functions %>%
-         map(~ .(ref_vec)) %>%
-         reduce(str_c) %>%
-         replace(. == "", NA)
-   } else {
-      na_index <- which(is.na(equations))
-      bad_defs <- grp_defs[na_index]
-      cli_abort(paste("Unable to decipher the following group definition{?s}: {bad_defs}.",
-                      "Please check your controlled terminology."))
-   }
-   # Find non-exclusive subgroups i.e., values that have been mapped to two groups
-   non_excl <- out |>
-      discard(is.na) |>
-      map(~ grp_labs[str_detect(.x, grp_labs)]) |>
-      keep(~ length(.) > 1) |>
-      unique()
+  # Apply equations
+  if (all(!is.na(equations))) {
+    functions <- equations %>%
+      map(~ eval(parse(text = .)))
+    out <- functions %>%
+      map(~ .(ref_vec)) %>%
+      reduce(str_c) %>%
+      replace(. == "", NA)
+  } else {
+    na_index <- which(is.na(equations))
+    bad_defs <- grp_defs[na_index]
+    cli_abort(paste(
+      "Unable to decipher the following group definition{?s}: {bad_defs}.",
+      "Please check your controlled terminology."
+    ))
+  }
+  # Find non-exclusive subgroups i.e., values that have been mapped to two groups
+  non_excl <- out |>
+    discard(is.na) |>
+    map(~ grp_labs[str_detect(.x, grp_labs)]) |>
+    keep(~ length(.) > 1) |>
+    unique()
 
-   # Throw error if groups are not exclusive
-   if (length(non_excl) > 0) {
-      msg <- map_chr(non_excl, ~ {
-         items <- paste(.x, collapse = ", ")
-      }) %>%
-         paste0(seq_along(.), ". ", .)
+  # Throw error if groups are not exclusive
+  if (length(non_excl) > 0) {
+    msg <- map_chr(non_excl, ~ {
+      items <- paste(.x, collapse = ", ")
+    }) %>%
+      paste0(seq_along(.), ". ", .)
 
-      cli_abort(c(
-         "Group definitions are not exclusive. Please check your controlled terminology",
-         "The following group definitions overlap:",
-         msg
-      ))
-   }
-   out
+    cli_abort(c(
+      "Group definitions are not exclusive. Please check your controlled terminology",
+      "The following group definitions overlap:",
+      msg
+    ))
+  }
+  out
 }
-
 
 
 #' Create Variable from Codelist
@@ -131,90 +135,94 @@ create_subgrps <- function(ref_vec, grp_defs, grp_labs = NULL) {
 #'
 #' # Example providing a custom codelist
 #' # This example also reverses the direction of translation
-#' load(metacore_example('pilot_ADaM.rda'))
+#' load(metacore_example("pilot_ADaM.rda"))
 #' adlb_spec <- select_dataset(metacore, "ADLBC", quiet = TRUE)
 #' adlb <- tibble(PARAMCD = c("ALB", "ALP", "ALT", "AST", "BILI", "BUN"))
 #' create_var_from_codelist(
-#'    adlb,
-#'    adlb_spec,
-#'    PARAMCD,
-#'    PARAM,
-#'    codelist = get_control_term(adlb_spec, PARAMCD),
-#'    decode_to_code = FALSE,
-#'    strict = FALSE)
+#'   adlb,
+#'   adlb_spec,
+#'   PARAMCD,
+#'   PARAM,
+#'   codelist = get_control_term(adlb_spec, PARAMCD),
+#'   decode_to_code = FALSE,
+#'   strict = FALSE
+#' )
 #'
-#'\dontrun{
+#' \dontrun{
 #' # Example expecting warning where `strict` == `TRUE`
 #' adlb <- tibble(PARAMCD = c("ALB", "ALP", "ALT", "AST", "BILI", "BUN", "DUMMY1", "DUMMY2"))
 #' create_var_from_codelist(
-#'    adlb,
-#'    adlb_spec,
-#'    PARAMCD,
-#'    PARAM,
-#'    codelist = get_control_term(adlb_spec, PARAMCD),
-#'    decode_to_code = FALSE,
-#'    strict = TRUE)
+#'   adlb,
+#'   adlb_spec,
+#'   PARAMCD,
+#'   PARAM,
+#'   codelist = get_control_term(adlb_spec, PARAMCD),
+#'   decode_to_code = FALSE,
+#'   strict = TRUE
+#' )
 #' }
 create_var_from_codelist <- function(data, metacore, input_var, out_var, codelist = NULL,
                                      decode_to_code = TRUE, strict = TRUE) {
-   verify_DatasetMeta(metacore)
+  verify_DatasetMeta(metacore)
 
-   # Use codelist if provided, else use codelist of the out_var
-   if (!missing(codelist)) { code_translation <- codelist }
-   else { code_translation <- get_control_term(metacore, {{ out_var }}) }
+  # Use codelist if provided, else use codelist of the out_var
+  if (!missing(codelist)) {
+    code_translation <- codelist
+  } else {
+    code_translation <- get_control_term(metacore, {{ out_var }})
+  }
 
-   if (is.vector(code_translation) | !("decode" %in% names(code_translation))) {
-      cli_abort("Expecting 'code_decode' type of control terminology. Actual \\
+  if (is.vector(code_translation) | !("decode" %in% names(code_translation))) {
+    cli_abort("Expecting 'code_decode' type of control terminology. Actual \\
 type is {typeof(code_translation)}. Check the structure of the codelist in the \\
 {.obj metacore} object using {.fn View}.")
-   }
+  }
 
-   # Check decode_to_code is logical and set direction of translation
-   if (!is_logical(decode_to_code)) {
-      cli_abort("{.arg decode_to_code} must be either TRUE or FALSE.")
-   }
+  # Check decode_to_code is logical and set direction of translation
+  if (!is_logical(decode_to_code)) {
+    cli_abort("{.arg decode_to_code} must be either TRUE or FALSE.")
+  }
 
-   ref_var <- if (decode_to_code) "decode" else "code"
-   new_var <- if (decode_to_code) "code"   else "decode"
+  ref_var <- if (decode_to_code) "decode" else "code"
+  new_var <- if (decode_to_code) "code" else "decode"
 
-   # Pull data values and codelist values to check inconsistent overlap
-   values   <- data |> pull({{ input_var }})
-   codelist <- code_translation |> pull(ref_var)
+  # Pull data values and codelist values to check inconsistent overlap
+  values <- data |> pull({{ input_var }})
+  codelist <- code_translation |> pull(ref_var)
 
-   miss <- setdiff(values, codelist)
-   n_miss <- length(miss)
-   if (strict == TRUE && n_miss > 0) {
-      cli_warn(
-         "In {.fn create_var_from_codelist}: The following {qty(n_miss)}value{?s}
-present in the input dataset {qty(n_miss)}{?is/are} not present in the codelist: {miss}")
-   }
+  miss <- setdiff(values, codelist)
+  n_miss <- length(miss)
+  if (strict == TRUE && n_miss > 0) {
+    cli_warn(
+      "In {.fn create_var_from_codelist}: The following {qty(n_miss)}value{?s}
+present in the input dataset {qty(n_miss)}{?is/are} not present in the codelist: {miss}"
+    )
+  }
 
-   input_var_str <- as_label(enexpr(input_var)) |>
-      str_remove_all("\"")
+  input_var_str <- as_label(enexpr(input_var)) |>
+    str_remove_all("\"")
 
-   # Coerce join column to character to ensure join if input var is numeric
-   data <- data |> mutate(merge_on := as.character(.data[[input_var_str]]))
-   code_translation <- code_translation |>
-      mutate(
-         decode = as.character(decode),
-         code = as.character(code)
-      )
+  # Coerce join column to character to ensure join if input var is numeric
+  data <- data |> mutate(merge_on := as.character(.data[[input_var_str]]))
+  code_translation <- code_translation |>
+    mutate(
+      decode = as.character(decode),
+      code = as.character(code)
+    )
 
-   out <- data |>
-      left_join(code_translation, by = set_names(ref_var, "merge_on")) |>
-      rename({{ out_var }} := !!sym(new_var)) |>
-      select(-merge_on)
+  out <- data |>
+    left_join(code_translation, by = set_names(ref_var, "merge_on")) |>
+    rename({{ out_var }} := !!sym(new_var)) |>
+    select(-merge_on)
 
-   # Optionally coerce to numeric if the output values are numeric
-   if (all(str_detect(code_translation[[new_var]], "^\\d*$"))) {
-      out <- out |>
-         mutate({{ out_var }} := as.numeric({{ out_var }}))
-   }
+  # Optionally coerce to numeric if the output values are numeric
+  if (all(str_detect(code_translation[[new_var]], "^\\d*$"))) {
+    out <- out |>
+      mutate({{ out_var }} := as.numeric({{ out_var }}))
+  }
 
-   out
+  out
 }
-
-
 
 
 #' Create Categorical Variable from Codelist
@@ -256,34 +264,38 @@ present in the input dataset {qty(n_miss)}{?is/are} not present in the codelist:
 #' create_cat_var(dm, spec, AGE, AGEGR1, AGEGR1N)
 create_cat_var <- function(data, metacore, ref_var, grp_var, num_grp_var = NULL,
                            create_from_decode = FALSE, strict = TRUE) {
-   verify_DatasetMeta(metacore)
-   ct <- get_control_term(metacore, {{ grp_var }})
-   if (is.vector(ct) | !("decode" %in% names(ct))) {
-      cli_abort("Expecting 'code_decode' type of control terminology. Please check metacore object")
-   }
+  verify_DatasetMeta(metacore)
+  ct <- get_control_term(metacore, {{ grp_var }})
+  if (is.vector(ct) | !("decode" %in% names(ct))) {
+    cli_abort("Expecting 'code_decode' type of control terminology. Please check metacore object")
+  }
 
-   # Assign group definitions and labels
-   grp_defs <- pull(ct, code)
-   grp_labs <- if (create_from_decode) pull(ct, decode) else grp_defs
+  # Assign group definitions and labels
+  grp_defs <- pull(ct, code)
+  grp_labs <- if (create_from_decode) pull(ct, decode) else grp_defs
 
-   out <- data %>%
-      mutate({{ grp_var }} := create_subgrps({{ ref_var }}, grp_defs, grp_labs))
+  out <- data %>%
+    mutate({{ grp_var }} := create_subgrps({{ ref_var }}, grp_defs, grp_labs))
 
-   if (!is.null(enexpr(num_grp_var))) {
-      out <- out %>%
-         create_var_from_codelist(metacore, {{ grp_var }}, {{ num_grp_var }})
-   }
+  if (!is.null(enexpr(num_grp_var))) {
+    out <- out %>%
+      create_var_from_codelist(metacore, {{ grp_var }}, {{ num_grp_var }})
+  }
 
-   missing <- out |> pull({{ grp_var }}) |> is.na() |> which()|> length()
-   if (strict && missing > 0) {
-      cli_warn(paste(
-         "There {qty(missing)} {?is/are} {missing} {qty(missing)} observation{?s}",
-         "in {as_name(enquo(ref_var))} that {qty(missing)} {?does/do} not fit into",
-         "the provided categories for {as_name(enquo(grp_var))}. Please check your",
-         "controlled terminology.")
-      )
-   }
-   out
+  missing <- out |>
+    pull({{ grp_var }}) |>
+    is.na() |>
+    which() |>
+    length()
+  if (strict && missing > 0) {
+    cli_warn(paste(
+      "There {qty(missing)} {?is/are} {missing} {qty(missing)} observation{?s}",
+      "in {as_name(enquo(ref_var))} that {qty(missing)} {?does/do} not fit into",
+      "the provided categories for {as_name(enquo(grp_var))}. Please check your",
+      "controlled terminology."
+    ))
+  }
+  out
 }
 
 
@@ -316,7 +328,7 @@ create_cat_var <- function(data, metacore, ref_var, grp_var, num_grp_var = NULL,
 #' # Variable with permitted value control terms
 #' convert_var_to_fct(dm, spec, ARM)
 convert_var_to_fct <- function(data, metacore, var) {
-   verify_DatasetMeta(metacore)
+  verify_DatasetMeta(metacore)
   code_translation <- get_control_term(metacore, {{ var }})
   var_str <- as_label(enexpr(var)) %>%
     str_remove_all("\"")
@@ -333,4 +345,3 @@ convert_var_to_fct <- function(data, metacore, var) {
   data %>%
     mutate({{ var }} := factor({{ var }}, levels = levels))
 }
-

--- a/man/add_labels.Rd
+++ b/man/add_labels.Rd
@@ -19,9 +19,9 @@ This function allows a user to apply several labels to a dataframe at once.
 }
 \examples{
 add_labels(
-    mtcars,
-    mpg = "Miles Per Gallon",
-    cyl = "Cylinders"
-  )
+  mtcars,
+  mpg = "Miles Per Gallon",
+  cyl = "Cylinders"
+)
 
 }

--- a/man/add_variables.Rd
+++ b/man/add_variables.Rd
@@ -35,6 +35,6 @@ library(dplyr)
 load(metacore_example("pilot_ADaM.rda"))
 spec <- metacore \%>\% select_dataset("ADSL")
 data <- read_xpt(metatools_example("adsl.xpt")) \%>\%
-   select(-TRTSDT, -TRT01P, -TRT01PN)
+  select(-TRTSDT, -TRT01P, -TRT01PN)
 add_variables(data, spec)
 }

--- a/man/combine_supp.Rd
+++ b/man/combine_supp.Rd
@@ -20,5 +20,5 @@ Combine the Domain and Supplemental Qualifier
 \examples{
 library(safetyData)
 library(tibble)
-combine_supp(sdtm_ae, sdtm_suppae)  \%>\% as_tibble()
+combine_supp(sdtm_ae, sdtm_suppae) \%>\% as_tibble()
 }

--- a/man/create_var_from_codelist.Rd
+++ b/man/create_var_from_codelist.Rd
@@ -69,28 +69,30 @@ create_var_from_codelist(data, dm_spec, VAR1, SEX, decode_to_code = FALSE)
 
 # Example providing a custom codelist
 # This example also reverses the direction of translation
-load(metacore_example('pilot_ADaM.rda'))
+load(metacore_example("pilot_ADaM.rda"))
 adlb_spec <- select_dataset(metacore, "ADLBC", quiet = TRUE)
 adlb <- tibble(PARAMCD = c("ALB", "ALP", "ALT", "AST", "BILI", "BUN"))
 create_var_from_codelist(
-   adlb,
-   adlb_spec,
-   PARAMCD,
-   PARAM,
-   codelist = get_control_term(adlb_spec, PARAMCD),
-   decode_to_code = FALSE,
-   strict = FALSE)
+  adlb,
+  adlb_spec,
+  PARAMCD,
+  PARAM,
+  codelist = get_control_term(adlb_spec, PARAMCD),
+  decode_to_code = FALSE,
+  strict = FALSE
+)
 
 \dontrun{
 # Example expecting warning where `strict` == `TRUE`
 adlb <- tibble(PARAMCD = c("ALB", "ALP", "ALT", "AST", "BILI", "BUN", "DUMMY1", "DUMMY2"))
 create_var_from_codelist(
-   adlb,
-   adlb_spec,
-   PARAMCD,
-   PARAM,
-   codelist = get_control_term(adlb_spec, PARAMCD),
-   decode_to_code = FALSE,
-   strict = TRUE)
+  adlb,
+  adlb_spec,
+  PARAMCD,
+  PARAM,
+  codelist = get_control_term(adlb_spec, PARAMCD),
+  decode_to_code = FALSE,
+  strict = TRUE
+)
 }
 }

--- a/man/set_variable_labels.Rd
+++ b/man/set_variable_labels.Rd
@@ -29,9 +29,9 @@ labels to a data frame.
 \examples{
 
 mc <- metacore::spec_to_metacore(
-        metacore::metacore_example("p21_mock.xlsx"),
-        quiet=TRUE
-        )
+  metacore::metacore_example("p21_mock.xlsx"),
+  quiet = TRUE
+)
 dm <- haven::read_xpt(metatools_example("dm.xpt"))
 set_variable_labels(dm, mc, dataset_name = "DM")
 }

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -65,11 +65,11 @@ test_that("create_var_from_codelist", {
   load(metacore::metacore_example('pilot_ADaM.rda'))
   adlb_spec <- metacore::select_dataset(metacore, "ADLBC", quiet = TRUE)
   data <- tibble::tibble(
-     PARAMCD = c("ALB", "ALP", "ALT", "DUMMY", "DUMMY2")
+     PARAMCD = c("ALB", "ALP", "ALT", "DUMMY")
   )
   compare <- tibble::tibble(
-     PARAMCD = c("ALB", "ALP", "ALT", "DUMMY", "DUMMY2"),
-     PARAM = c("Albumin (g/L)", "Alkaline Phosphatase (U/L)", "Alanine Aminotransferase (U/L)", NA, NA)
+     PARAMCD = c("ALB", "ALP", "ALT", "DUMMY"),
+     PARAM = c("Albumin (g/L)", "Alkaline Phosphatase (U/L)", "Alanine Aminotransferase (U/L)", NA)
   )
 
   create_var_from_codelist(
@@ -84,7 +84,23 @@ test_that("create_var_from_codelist", {
      select(PARAMCD, PARAM) |>
      expect_equal(compare)
 
-  # Test warning where arg `strict == TRUE`
+  # Test character variable warning where arg `strict == TRUE` / single issue case
+  create_var_from_codelist(
+     data = data,
+     metacore = adlb_spec,
+     input_var = PARAMCD,
+     out_var = PARAM,
+     codelist = get_control_term(adlb_spec, PARAMCD),
+     decode_to_code = FALSE,
+     strict = TRUE
+  ) |>
+     expect_warning()
+
+  # Test character variable warning where arg `strict == TRUE` / multiple issue case
+  data <- tibble::tibble(
+     PARAMCD = c("ALB", "ALP", "ALT", "DUMMY", "DUMMY2")
+  )
+
   create_var_from_codelist(
      data = data,
      metacore = adlb_spec,
@@ -117,9 +133,25 @@ test_that("create_var_from_codelist", {
      select(PARAMN, PARAM) |>
      expect_equal(compare2)
 
-  # Test numeric variable used as input_var (strict == TRUE)
+  # Test numeric variable used as input_var / single issue case (strict == TRUE)
   create_var_from_codelist(
      data = data2,
+     metacore = adlb_spec,
+     input_var = PARAMN,
+     out_var = PARAM,
+     codelist = get_control_term(adlb_spec, PARAMN),
+     decode_to_code = FALSE,
+     strict = TRUE
+  ) |>
+     expect_warning()
+
+  # Test numeric variable used as input_var / multiple issue case (strict == TRUE)
+  data3 <- tibble::tibble(
+     PARAMN = c(18, 19, 20, 99, 999)
+  )
+
+  create_var_from_codelist(
+     data = data3,
      metacore = adlb_spec,
      input_var = PARAMN,
      out_var = PARAM,

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -163,8 +163,8 @@ test_that("create_var_from_codelist", {
 
   # Test for Variable not in specs
   expect_error(
-     create_var_from_codelist(data, adlb_spec, VAR2, FOO),
-     regexp = cli_inform(c("!" = "FOO not found in the value_spec table. Please check the variable name"))
+    create_var_from_codelist(data, adlb_spec, VAR2, FOO),
+    regexp = cli_inform(c("!" = "FOO not found in the value_spec table. Please check the variable name"))
   )
 })
 

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -86,19 +86,19 @@ test_that("create_var_from_codelist", {
 
   # Test character variable warning where arg `strict == TRUE` / single issue case
   create_var_from_codelist(
-     data = data,
-     metacore = adlb_spec,
-     input_var = PARAMCD,
-     out_var = PARAM,
-     codelist = get_control_term(adlb_spec, PARAMCD),
-     decode_to_code = FALSE,
-     strict = TRUE
+    data = data,
+    metacore = adlb_spec,
+    input_var = PARAMCD,
+    out_var = PARAM,
+    codelist = get_control_term(adlb_spec, PARAMCD),
+    decode_to_code = FALSE,
+    strict = TRUE
   ) |>
-     expect_warning()
+    expect_warning()
 
   # Test character variable warning where arg `strict == TRUE` / multiple issue case
   data <- tibble::tibble(
-     PARAMCD = c("ALB", "ALP", "ALT", "DUMMY", "DUMMY2")
+    PARAMCD = c("ALB", "ALP", "ALT", "DUMMY", "DUMMY2")
   )
 
   create_var_from_codelist(
@@ -147,19 +147,19 @@ test_that("create_var_from_codelist", {
 
   # Test numeric variable used as input_var / multiple issue case (strict == TRUE)
   data3 <- tibble::tibble(
-     PARAMN = c(18, 19, 20, 99, 999)
+    PARAMN = c(18, 19, 20, 99, 999)
   )
 
   create_var_from_codelist(
-     data = data3,
-     metacore = adlb_spec,
-     input_var = PARAMN,
-     out_var = PARAM,
-     codelist = get_control_term(adlb_spec, PARAMN),
-     decode_to_code = FALSE,
-     strict = TRUE
+    data = data3,
+    metacore = adlb_spec,
+    input_var = PARAMN,
+    out_var = PARAM,
+    codelist = get_control_term(adlb_spec, PARAMN),
+    decode_to_code = FALSE,
+    strict = TRUE
   ) |>
-     expect_warning()
+    expect_warning()
 
   # Test for Variable not in specs
   expect_error(create_var_from_codelist(data, spec, VAR2, FOO))

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -90,7 +90,7 @@ test_that("create_var_from_codelist", {
     metacore = adlb_spec,
     input_var = PARAMCD,
     out_var = PARAM,
-    codelist = get_control_term(adlb_spec, PARAMCD),
+    codelist = metacore::get_control_term(adlb_spec, PARAMCD),
     decode_to_code = FALSE,
     strict = TRUE
   ) |>

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -162,7 +162,10 @@ test_that("create_var_from_codelist", {
     expect_warning()
 
   # Test for Variable not in specs
-  expect_error(create_var_from_codelist(data, spec, VAR2, FOO))
+  expect_error(
+     create_var_from_codelist(data, adlb_spec, VAR2, FOO),
+     regexp = cli_inform(c("!" = "FOO not found in the value_spec table. Please check the variable name"))
+  )
 })
 
 test_that("create_cat_var", {


### PR DESCRIPTION
Closes #99 

This bug occurred only when there were multiple values from a numeric type input column that were not present in the codelist i.e., values of 99 and 999 in the dataset but no appropriate record in the CT. 

The fix just required placing a `cli::qty()` check prior to the glue substitution that uses pluralization.

This wasn't caught in testing because the test case only had a single value of wrong CT in the test dataset. I have expanded the test cases to include both single and multiple bad CT for both character and numeric input.