### PR TITLE
Bugfix `create_var_from_codelist` closes #111

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # metatools 0.3.0
-* Bugfix issue in `create_var_from_codelist` where supplied codelist contains negative numeric values. (#111)
+* Bugfix issue in `create_var_from_codelist()` where supplied codelist contains negative numeric values. (#111)
 
 # metatools 0.2.0
 * Functions now require a subsetted metacore object to be used i.e., created via `metacore::select_dataset()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # metatools 0.3.0
+* Bugfix issue in `create_var_from_codelist` where supplied codelist contains negative numeric values. (#111)
 
 # metatools 0.2.0
 * Functions now require a subsetted metacore object to be used i.e., created via `metacore::select_dataset()`.

--- a/R/codelists.R
+++ b/R/codelists.R
@@ -205,7 +205,7 @@ input dataset {?is/are} not present in the codelist: {miss}")
       select(-merge_on)
 
    # Optionally coerce to numeric if the output values are numeric
-   if (all(str_detect(code_translation[[new_var]], "^\\d*$"))) {
+   if (all(str_detect(code_translation[[new_var]], "^-?\\d*$"))) {
       out <- out |>
          mutate({{ out_var }} := as.numeric({{ out_var }}))
    }
@@ -264,7 +264,7 @@ create_cat_var <- function(data, metacore, ref_var, grp_var, num_grp_var = NULL,
    # Assign group definitions and labels
    grp_defs <- pull(ct, code)
    grp_labs <- if (create_from_decode) pull(ct, decode) else grp_defs
-     
+
    out <- data %>%
       mutate({{ grp_var }} := create_subgrps({{ ref_var }}, grp_defs, grp_labs))
 

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -129,6 +129,37 @@ test_that("create_var_from_codelist", {
   ) |>
      expect_warning()
 
+  # Test numeric codelist with negative numbers
+  data <- tibble::tibble(
+     USUBJID = c(1, 2, 3, 4, 5),
+     VAR = c("Male", "Female", "Female", "Unknown", "Male")
+  )
+
+  manual_data <- tibble::tibble(
+     USUBJID = c(1, 2, 3, 4, 5),
+     VAR = c("Male", "Female", "Female", "Unknown", "Male"),
+     SEX = c(2, 1, 1, -999, 2),
+  )
+
+  dm_spec <- metacore::metacore(
+     quiet = TRUE,
+     ds_spec = spec$ds_spec,
+     ds_vars = spec$ds_vars,
+     var_spec = spec$var_spec,
+     value_spec = mutate(spec$value_spec, code_id = case_when(code_id != "SEX" ~ NA, TRUE ~ "SEX")),
+     derivations = spec$derivations,
+     supp = spec$supp,
+     codelist = structure(
+        list(
+           code_id = structure("SEX", label = "ID of the Code List"),
+           name = "SEX",
+           type = structure("code_decode", label = "Code List/Permitted Values/External Library"),
+           codes = structure(list(structure(list(code = c(1, 2, -999), decode = c("Female", "Male", "Unknown")),     row.names = c(NA, -3L), class = c("tbl_df", "tbl", "data.frame"))), label = "List of Codes")), row.names = c(NA, -1L),   class = c("tbl_df", "tbl", "data.frame"))) %>%
+     select_dataset( "DM", quiet = TRUE)
+
+  create_var_from_codelist(data, dm_spec, VAR, SEX) %>%
+     expect_equal(manual_data)
+
   # Test for Variable not in specs
   expect_error(create_var_from_codelist(data, spec, VAR2, FOO))
 })


### PR DESCRIPTION
Closes #111 

Updated regex in final check to also consider negative numbers and added test case to verify. Previously these columns were not converted to numeric after the new variable was created.