### PR TITLE
feat: add Associated Persons (AP) domain support

### DIFF
--- a/R/supp.R
+++ b/R/supp.R
@@ -21,7 +21,7 @@ build_qnam <- function(dataset, qnam, qlabel, idvar, qeval, qorig,
                        verbose = c("message", "warn", "silent")) {
   verbose <- validate_verbose(verbose)
 
-    # Detect whether this is an AP domain (APID) or standard domain (USUBJID)
+  # Detect whether this is an AP domain (APID) or standard domain (USUBJID)
   is_ap <- "APID" %in% names(dataset)
   is_subject <- "USUBJID" %in% names(dataset)
 
@@ -73,7 +73,8 @@ build_qnam <- function(dataset, qnam, qlabel, idvar, qeval, qorig,
   test_out <- dup_sup %>%
     distinct()
   if (nrow(out) != nrow(test_out)) {
-    stop(paste0(
+    stop(
+      paste0(
         "The combination of STUDYID, RDOMAIN, ", id_var, ", IDVARVAL, QNAM is ambiguous. Consider modifying the IDVAR"
       ),
       call. = FALSE
@@ -175,7 +176,7 @@ combine_supp <- function(dataset, supp) {
     return(dataset)
   }
 
-    # Detect whether this is an AP supp (APID) or standard supp (USUBJID)
+  # Detect whether this is an AP supp (APID) or standard supp (USUBJID)
   is_ap <- "APID" %in% names(supp)
   is_subject <- "USUBJID" %in% names(supp)
 
@@ -220,9 +221,9 @@ combine_supp <- function(dataset, supp) {
     stop("Parent dataset contains both APID and USUBJID. Only one is permitted.", call. = FALSE)
   }
 
-    # Validate that required key columns are present in the parent dataset
+  # Validate that required key columns are present in the parent dataset
   required_parent_cols <- c("STUDYID", "DOMAIN", id_var)
-  mis_parent_col <- setdiff(required_parent_cols,  names(dataset))
+  mis_parent_col <- setdiff(required_parent_cols, names(dataset))
 
   if (length(mis_parent_col) > 0) {
     stop(

--- a/tests/testthat/test-supp.R
+++ b/tests/testthat/test-supp.R
@@ -485,7 +485,6 @@ test_that("combine_supp: extra SUPP rows that do not match core raise a warning 
 })
 
 test_that("combine_supp:errors if supp has both APID and USUBJID", {
-
   dataset <- data.frame(
     STUDYID = "S1",
     DOMAIN  = "AE",
@@ -514,7 +513,6 @@ test_that("combine_supp:errors if supp has both APID and USUBJID", {
 
 
 test_that("combine_supp:errors if supp has neither APID nor USUBJID", {
-
   dataset <- data.frame(
     STUDYID = "S1",
     DOMAIN  = "AE",
@@ -540,7 +538,6 @@ test_that("combine_supp:errors if supp has neither APID nor USUBJID", {
 })
 
 test_that("combine_supp:supports APID-based supplemental datasets", {
-
   dataset <- data.frame(
     STUDYID = "S1",
     DOMAIN  = "APSC",
@@ -568,7 +565,6 @@ test_that("combine_supp:supports APID-based supplemental datasets", {
 })
 
 test_that("combine_supp:errors if parent dataset has both APID and USUBJID", {
-
   dataset <- data.frame(
     STUDYID = "S1",
     DOMAIN  = "AE",
@@ -596,7 +592,6 @@ test_that("combine_supp:errors if parent dataset has both APID and USUBJID", {
 })
 
 test_that("combine_supp:errors when required parent key columns are missing", {
-
   dataset <- data.frame(
     STUDYID = "S1",
     DOMAIN  = "AE",
@@ -796,4 +791,3 @@ test_that("build_qnam: uses APID when present and returns APID column (not USUBJ
   expect_false("USUBJID" %in% names(out))
   expect_identical(out$APID, c("A01", "A01"))
 })
-


### PR DESCRIPTION
## Summary

Adds Associated Persons (AP) domain support to `combine_supp` and `build_qnam`

## Changes

### `combine_supp`
- Detects whether the supp dataset uses `APID` or `USUBJID` and resolves `id_var` dynamically
- Errors if both `APID` and `USUBJID` are present in the supp dataset
- Errors if neither `APID` nor `USUBJID` are present in the supp dataset
- Errors if both `APID` and `USUBJID` are present in the parent dataset
- Validates that `STUDYID`, `DOMAIN`, and the resolved `id_var` are present in the parent dataset

### `combine_supp_join`
- Updated `by` key resolution to include `APID` alongside `USUBJID`

### `build_qnam`
- Detects whether the dataset uses `APID` or `USUBJID` and resolves `id_var` dynamically
- Errors if both `APID` and `USUBJID` are present in the dataset
- Errors if neither `APID` nor `USUBJID` are present in the dataset
- Updated `select`, `distinct`, and output column to use resolved `id_var`
- Updated ambiguity error message to reference the resolved `id_var`

## Tests

New tests added for both `combine_supp` and `build_qnam` covering:
- Happy path for both `USUBJID` and `APID` domains
- Error cases for both/neither ID column scenarios
- Required parent column validation
- `IDVAR` column existence validation
- Correct output structure, column names, and values for AP domains
- Blank and `NA` `IDVAR` handling for subject-level records
- Ambiguity error message referencing the correct ID column
- Multiple subjects in AP datasets